### PR TITLE
orders配置中使用`db.*`时，carry无法truncate db中的所有表。并且会报错NotImplementedError

### DIFF
--- a/carry/__init__.py
+++ b/carry/__init__.py
@@ -52,14 +52,16 @@ class Carry(object):
         sources = task.get('from')
         dest = task.get('to')
         orders = task.get('orders')
-
+        sourceName =''
+        for source in sources:
+            sourceName=source['name']
         logger.info('Start task {}: Transfer tables from {} to {}'.format(
             num, [source['name'] for source in sources], dest['name'])
         )
 
         # truncate
         tc = TaskClassifier(orders)
-        effected_tables = tc.effected_tables()
+        effected_tables = tc.effected_tables(sourceName,self.stores.stores)
         dest_store = self.stores.find_by_store_name(dest['name'])
         dest_store.truncate(effected_tables)
 

--- a/carry/task.py
+++ b/carry/task.py
@@ -48,7 +48,7 @@ class TaskClassifier(object):
     def __init__(self, tasks):
         self.tasks = tasks
 
-    def effected_tables(self):
+    def effected_tables(self,sourceName,stors):
         tables = []
         for task_config in self.tasks:
             if isinstance(task_config, (TableTaskConfig, SQLTaskConfig)):
@@ -66,7 +66,10 @@ class TaskClassifier(object):
                     tables.append(task_config.split('.sql')[0])
                 # TODO
                 elif '.*' in task_config:
-                    pass
+                    for stor in stors:
+                        if sourceName == stor.name:
+                            tbs = stor.materialized_tables
+                            tables.append(tbs)
                 else:
                     raise NotImplementedError
             elif isinstance(task_config, TableTaskConfig):


### PR DESCRIPTION
orders配置中使用`db.*`时，carry无法truncate db中的所有表。并且会报错NotImplementedError